### PR TITLE
No longer export SELECTIVE_RUN_ID and SELECTIVE_RUN_ATTEMPT variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,4 @@ jobs:
       - name: Print Output
         id: output
         run: |
-          echo "SELECTIVE_RUN_ID: $SELECTIVE_RUN_ID"
           echo "SELECTIVE_RUNNER_ID: $SELECTIVE_RUNNER_ID"
-          echo "SELECTIVE_RUN_ATTEMPT: $SELECTIVE_RUN_ATTEMPT"

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -25,7 +25,7 @@ describe('run', () => {
     jest.clearAllMocks()
   })
 
-  it('exports SELECTIVE_RUNNER_ID, SELECTIVE_RUN_ID, and SELECTIVE_RUN_ATTEMPT variables', async () => {
+  it('exports SELECTIVE_RUNNER_ID variable', async () => {
     // Mock the getInput function
     // eslint-disable-next-line no-extra-semi
     ;(core.getInput as jest.Mock)
@@ -35,14 +35,6 @@ describe('run', () => {
     await run()
 
     expect(core.exportVariable).toHaveBeenCalledWith('SELECTIVE_RUNNER_ID', '1')
-    expect(core.exportVariable).toHaveBeenCalledWith(
-      'SELECTIVE_RUN_ID',
-      process.env.GITHUB_RUN_ID
-    )
-    expect(core.exportVariable).toHaveBeenCalledWith(
-      'SELECTIVE_RUN_ATTEMPT',
-      process.env.GITHUB_RUN_ATTEMPT
-    )
   })
 
   it('exports SELECTIVE_PR_TITLE variable for pull_request event', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -28522,8 +28522,6 @@ async function run() {
         if (runnerId) {
             core.exportVariable('SELECTIVE_RUNNER_ID', runnerId);
         }
-        core.exportVariable('SELECTIVE_RUN_ID', process.env.GITHUB_RUN_ID);
-        core.exportVariable('SELECTIVE_RUN_ATTEMPT', process.env.GITHUB_RUN_ATTEMPT);
         if (github.context.eventName === 'pull_request') {
             core.exportVariable('SELECTIVE_PR_TITLE', github.context.payload.pull_request?.title);
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,9 +26,6 @@ export async function run(): Promise<void> {
       core.exportVariable('SELECTIVE_RUNNER_ID', runnerId)
     }
 
-    core.exportVariable('SELECTIVE_RUN_ID', process.env.GITHUB_RUN_ID)
-    core.exportVariable('SELECTIVE_RUN_ATTEMPT', process.env.GITHUB_RUN_ATTEMPT)
-
     if (github.context.eventName === 'pull_request') {
       core.exportVariable(
         'SELECTIVE_PR_TITLE',


### PR DESCRIPTION
These variables are set by GitHub Actions so we don't need to export them as well.