### PR TITLE
Group eslint ecosystem packages in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - "eslint"
+          - "eslint-*"
+          - "eslint-plugin-*"
+          - "eslint-config-*"


### PR DESCRIPTION
## Summary
- Adds an `eslint` group to `.github/dependabot.yml` that bundles all `@typescript-eslint/*`, `eslint`, `eslint-plugin-*`, and `eslint-config-*` packages into a single weekly PR.

## Why
PRs #53 (eslint-plugin) and #64 (eslint-plugin-jest) couldn't merge in isolation because their peer-dep ranges depend on each other and on `eslint-plugin-github`. Single-package bumps from dependabot kept hitting `ERESOLVE` errors. Grouping these so they move together is the standard fix — see #67 which had to bump four packages together to land typescript-eslint v8.

## Test plan
- [ ] Next dependabot run produces a single grouped PR for the eslint ecosystem instead of separate ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)