### PR TITLE
Ignore major bumps for typescript, eslint, eslint-plugin-github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,14 @@ updates:
           - "eslint-*"
           - "eslint-plugin-*"
           - "eslint-config-*"
+    ignore:
+      # eslint v9+ requires migrating to flat config (eslint.config.js).
+      # Hold at v8 until that migration is done deliberately.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-plugin-github"
+        update-types: ["version-update:semver-major"]
+      # TypeScript majors are big enough to warrant a deliberate evaluation
+      # rather than an automated bump (cf. closed PR #76 for TS 5 -> 6).
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
Adds dependabot \`ignore\` rules for the major version bumps that need deliberate migration:
- **eslint** — v9+ drops legacy \`.eslintrc.yml\` in favor of flat config (\`eslint.config.js\`)
- **eslint-plugin-github** — v6 requires eslint v9+ (same migration)
- **typescript** — TS 6 breaks ts-jest and ncc bundling for this project (cf. closed #76)

## Why
Dependabot keeps proposing these majors and they keep failing CI because they need real migration work, not a version bump. Pinning the floor stops the noise. Removing an entry here is the deliberate signal that we're ready to do the migration.

## Test plan
- [ ] Next dependabot run skips eslint/eslint-plugin-github/typescript major bumps
- [ ] Minors and patches still flow through

🤖 Generated with [Claude Code](https://claude.com/claude-code)